### PR TITLE
Refactor treesitter textobjects module

### DIFF
--- a/.config/nvim/lua/plugins/nvim-treesitter-textobjects.lua
+++ b/.config/nvim/lua/plugins/nvim-treesitter-textobjects.lua
@@ -1,109 +1,117 @@
--- configuration
-require("nvim-treesitter-textobjects").setup {
-  select = {
-    -- Automatically jump forward to textobj, similar to targets.vim
-    lookahead = true,
-    -- You can choose the select mode (default is charwise 'v')
-    --
-    -- Can also be a function which gets passed a table with the keys
-    -- * query_string: eg '@function.inner'
-    -- * method: eg 'v' or 'o'
-    -- and should return the mode ('v', 'V', or '<c-v>') or a table
-    -- mapping query_strings to modes.
-    selection_modes = {
-      ['@parameter.outer'] = 'v', -- charwise
-      ['@function.outer'] = 'V', -- linewise
-      ['@class.outer'] = '<c-v>', -- blockwise
+-- configuration for nvim-treesitter textobjects
+local M = {}
+
+function M.setup()
+  -- configure textobjects via nvim-treesitter
+  require('nvim-treesitter.configs').setup {
+    textobjects = {
+      select = {
+        -- Automatically jump forward to textobj, similar to targets.vim
+        lookahead = true,
+        -- You can choose the select mode (default is charwise 'v')
+        --
+        -- Can also be a function which gets passed a table with the keys
+        -- * query_string: eg '@function.inner'
+        -- * method: eg 'v' or 'o'
+        -- and should return the mode ('v', 'V', or '<c-v>') or a table
+        -- mapping query_strings to modes.
+        selection_modes = {
+          ['@parameter.outer'] = 'v', -- charwise
+          ['@function.outer'] = 'V', -- linewise
+          ['@class.outer']    = '<c-v>', -- blockwise
+        },
+        -- If you set this to `true` (default is `false`) then any textobject is
+        -- extended to include preceding or succeeding whitespace. Succeeding
+        -- whitespace has priority in order to act similarly to eg the built-in
+        -- `ap`.
+        --
+        -- Can also be a function which gets passed a table with the keys
+        -- * query_string: eg '@function.inner'
+        -- * selection_mode: eg 'v'
+        -- and should return true of false
+        include_surrounding_whitespace = false,
+      },
+      move = {
+        -- whether to set jumps in the jumplist
+        set_jumps = true,
+      },
     },
-    -- If you set this to `true` (default is `false`) then any textobject is
-    -- extended to include preceding or succeeding whitespace. Succeeding
-    -- whitespace has priority in order to act similarly to eg the built-in
-    -- `ap`.
-    --
-    -- Can also be a function which gets passed a table with the keys
-    -- * query_string: eg '@function.inner'
-    -- * selection_mode: eg 'v'
-    -- and should return true of false
-    include_surrounding_whitespace = false,
+  }
 
-  },
-  move = {
-    -- whether to set jumps in the jumplist
-    set_jumps = true,
-  },
-}
+  -- keymaps
+  -- Text objects: select
+  -- You can use the capture groups defined in `textobjects.scm`
+  vim.keymap.set({ 'x', 'o' }, 'af', function()
+    require('nvim-treesitter-textobjects.select').select_textobject('@function.outer', 'textobjects')
+  end)
+  vim.keymap.set({ 'x', 'o' }, 'if', function()
+    require('nvim-treesitter-textobjects.select').select_textobject('@function.inner', 'textobjects')
+  end)
+  vim.keymap.set({ 'x', 'o' }, 'ac', function()
+    require('nvim-treesitter-textobjects.select').select_textobject('@class.outer', 'textobjects')
+  end)
+  vim.keymap.set({ 'x', 'o' }, 'ic', function()
+    require('nvim-treesitter-textobjects.select').select_textobject('@class.inner', 'textobjects')
+  end)
+  -- You can also use captures from other query groups like `locals.scm`
+  vim.keymap.set({ 'x', 'o' }, 'as', function()
+    require('nvim-treesitter-textobjects.select').select_textobject('@local.scope', 'locals')
+  end)
 
--- keymaps
--- Text objects: select
--- You can use the capture groups defined in `textobjects.scm`
-vim.keymap.set({ "x", "o" }, "af", function()
-  require "nvim-treesitter-textobjects.select".select_textobject("@function.outer", "textobjects")
-end)
-vim.keymap.set({ "x", "o" }, "if", function()
-  require "nvim-treesitter-textobjects.select".select_textobject("@function.inner", "textobjects")
-end)
-vim.keymap.set({ "x", "o" }, "ac", function()
-  require "nvim-treesitter-textobjects.select".select_textobject("@class.outer", "textobjects")
-end)
-vim.keymap.set({ "x", "o" }, "ic", function()
-  require "nvim-treesitter-textobjects.select".select_textobject("@class.inner", "textobjects")
-end)
--- You can also use captures from other query groups like `locals.scm`
-vim.keymap.set({ "x", "o" }, "as", function()
-  require "nvim-treesitter-textobjects.select".select_textobject("@local.scope", "locals")
-end)
+  -- Text objects: swap
+  vim.keymap.set('n', '<leader>a', function()
+    require('nvim-treesitter-textobjects.swap').swap_next '@parameter.inner'
+  end)
+  vim.keymap.set('n', '<leader>A', function()
+    require('nvim-treesitter-textobjects.swap').swap_previous '@parameter.outer'
+  end)
+  vim.keymap.set({ 'n', 'x', 'o' }, ']m', function()
+    require('nvim-treesitter-textobjects.move').goto_next_start('@function.outer', 'textobjects')
+  end)
+  vim.keymap.set({ 'n', 'x', 'o' }, ']]', function()
+    require('nvim-treesitter-textobjects.move').goto_next_start('@class.outer', 'textobjects')
+  end)
+  -- You can also pass a list to group multiple queries.
+  vim.keymap.set({ 'n', 'x', 'o' }, ']o', function()
+    require('nvim-treesitter-textobjects.move').goto_next_start({ '@loop.inner', '@loop.outer' }, 'textobjects')
+  end)
+  -- You can also use captures from other query groups like `locals.scm` or `folds.scm`
+  vim.keymap.set({ 'n', 'x', 'o' }, ']s', function()
+    require('nvim-treesitter-textobjects.move').goto_next_start('@local.scope', 'locals')
+  end)
+  vim.keymap.set({ 'n', 'x', 'o' }, ']z', function()
+    require('nvim-treesitter-textobjects.move').goto_next_start('@fold', 'folds')
+  end)
 
--- Text objects: swap
-vim.keymap.set("n", "<leader>a", function()
-  require("nvim-treesitter-textobjects.swap").swap_next "@parameter.inner"
-end)
-vim.keymap.set("n", "<leader>A", function()
-  require("nvim-treesitter-textobjects.swap").swap_previous "@parameter.outer"
-end)
-vim.keymap.set({ "n", "x", "o" }, "]m", function()
-  require("nvim-treesitter-textobjects.move").goto_next_start("@function.outer", "textobjects")
-end)
-vim.keymap.set({ "n", "x", "o" }, "]]", function()
-  require("nvim-treesitter-textobjects.move").goto_next_start("@class.outer", "textobjects")
-end)
--- You can also pass a list to group multiple queries.
-vim.keymap.set({ "n", "x", "o" }, "]o", function()
-  move.goto_next_start({"@loop.inner", "@loop.outer"}, "textobjects")
-end)
--- You can also use captures from other query groups like `locals.scm` or `folds.scm`
-vim.keymap.set({ "n", "x", "o" }, "]s", function()
-  require("nvim-treesitter-textobjects.move").goto_next_start("@local.scope", "locals")
-end)
-vim.keymap.set({ "n", "x", "o" }, "]z", function()
-  require("nvim-treesitter-textobjects.move").goto_next_start("@fold", "folds")
-end)
+  vim.keymap.set({ 'n', 'x', 'o' }, ']M', function()
+    require('nvim-treesitter-textobjects.move').goto_next_end('@function.outer', 'textobjects')
+  end)
+  vim.keymap.set({ 'n', 'x', 'o' }, '][', function()
+    require('nvim-treesitter-textobjects.move').goto_next_end('@class.outer', 'textobjects')
+  end)
 
-vim.keymap.set({ "n", "x", "o" }, "]M", function()
-  require("nvim-treesitter-textobjects.move").goto_next_end("@function.outer", "textobjects")
-end)
-vim.keymap.set({ "n", "x", "o" }, "][", function()
-  require("nvim-treesitter-textobjects.move").goto_next_end("@class.outer", "textobjects")
-end)
+  vim.keymap.set({ 'n', 'x', 'o' }, '[m', function()
+    require('nvim-treesitter-textobjects.move').goto_previous_start('@function.outer', 'textobjects')
+  end)
+  vim.keymap.set({ 'n', 'x', 'o' }, '[[', function()
+    require('nvim-treesitter-textobjects.move').goto_previous_start('@class.outer', 'textobjects')
+  end)
 
-vim.keymap.set({ "n", "x", "o" }, "[m", function()
-  require("nvim-treesitter-textobjects.move").goto_previous_start("@function.outer", "textobjects")
-end)
-vim.keymap.set({ "n", "x", "o" }, "[[", function()
-  require("nvim-treesitter-textobjects.move").goto_previous_start("@class.outer", "textobjects")
-end)
+  vim.keymap.set({ 'n', 'x', 'o' }, '[M', function()
+    require('nvim-treesitter-textobjects.move').goto_previous_end('@function.outer', 'textobjects')
+  end)
+  vim.keymap.set({ 'n', 'x', 'o' }, '[]', function()
+    require('nvim-treesitter-textobjects.move').goto_previous_end('@class.outer', 'textobjects')
+  end)
 
-vim.keymap.set({ "n", "x", "o" }, "[M", function()
-  require("nvim-treesitter-textobjects.move").goto_previous_end("@function.outer", "textobjects")
-end)
-vim.keymap.set({ "n", "x", "o" }, "[]", function()
-  require("nvim-treesitter-textobjects.move").goto_previous_end("@class.outer", "textobjects")
-end)
+  -- Go to either the start or the end, whichever is closer.
+  -- Use if you want more granular movements
+  vim.keymap.set({ 'n', 'x', 'o' }, ']d', function()
+    require('nvim-treesitter-textobjects.move').goto_next('@conditional.outer', 'textobjects')
+  end)
+  vim.keymap.set({ 'n', 'x', 'o' }, '[d', function()
+    require('nvim-treesitter-textobjects.move').goto_previous('@conditional.outer', 'textobjects')
+  end)
+end
 
--- Go to either the start or the end, whichever is closer.
--- Use if you want more granular movements
-vim.keymap.set({ "n", "x", "o" }, "]d", function()
-  require("nvim-treesitter-textobjects.move").goto_next("@conditional.outer", "textobjects")
-end)
-vim.keymap.set({ "n", "x", "o" }, "[d", function()
-  require("nvim-treesitter-textobjects.move").goto_previous("@conditional.outer", "textobjects")
-end)
+return M


### PR DESCRIPTION
## Summary
- refactor textobject setup to expose a `setup()` function
- configure textobjects using `nvim-treesitter.configs`
- move keymaps inside the new setup function

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688066a1678c832face534e4a6729e17