### PR TITLE
Fix incremental selection keymap typo

### DIFF
--- a/.config/nvim/lua/plugins/nvim-treesitter.lua
+++ b/.config/nvim/lua/plugins/nvim-treesitter.lua
@@ -21,7 +21,7 @@ function M.setup()
       keymaps = {
         init_selection      = "<Enter>", -- set to `false` to disable one of the mappings
         node_incremental    = "<Enter>",
-        scope_incremenetal  = false,
+        scope_incremental  = false,
         node_decremental    = "<Backspace>",
       },
     },


### PR DESCRIPTION
## Summary
- fix a typo in `nvim-treesitter` config

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688066a5a8f4832f8b22395def5eddc7